### PR TITLE
New feature "auth_by", code and tests refatorations, 

### DIFF
--- a/lib/auth/bcrypt.ex
+++ b/lib/auth/bcrypt.ex
@@ -51,17 +51,14 @@ defmodule Entrance.Auth.Bcrypt do
   end
 
   @doc """
-  Compares the given `password` against the given `user`'ss password.
+  Compares the given `password` against the given `user`'s password.
   """
-  def authenticate(user, password) do
-    Bcrypt.verify_pass(password, user.hashed_password)
-  end
+  def authenticate(user, password),
+    do: Bcrypt.verify_pass(password, user.hashed_password)
 
   @doc """
   Simulates password check to help prevent timing attacks. Delegates to
   `Bcrypt.no_user_verify/0`.
   """
-  def no_user_verify() do
-    Bcrypt.no_user_verify()
-  end
+  def no_user_verify(), do: Bcrypt.no_user_verify()
 end

--- a/lib/auth/bcrypt.ex
+++ b/lib/auth/bcrypt.ex
@@ -18,17 +18,17 @@ defmodule Entrance.Auth.Bcrypt do
 
     def create_changeset(struct, changes) do
       struct
-        |> cast(changes, ~w(email password))
-        |> hash_password
+      |> cast(changes, ~w(email password))
+      |> hash_password
     end
   end
   ```
 
-  To authenticate a user in your application, you can use `authenticate/2`:
+  To authenticate a user in your application, you can use `auth/2`:
 
   ```
   user = Repo.get(User, 1)
-  User.authenticate(user, "password")
+  User.auth(user, "password")
   ```
   """
   alias Ecto.Changeset
@@ -52,8 +52,17 @@ defmodule Entrance.Auth.Bcrypt do
 
   @doc """
   Compares the given `password` against the given `user`'s password.
+
+  ## Example
+
+  ```
+  user = %{hashed_password: "iHkKDjU_example"}
+  password = "user@password"
+  Entrance.Auth.Bcrypt.auth(user, password)
+  ```
+
   """
-  def authenticate(user, password),
+  def auth(user, password),
     do: Bcrypt.verify_pass(password, user.hashed_password)
 
   @doc """

--- a/lib/auth/secret.ex
+++ b/lib/auth/secret.ex
@@ -37,9 +37,8 @@ defmodule Entrance.Auth.Secret do
   @doc """
   Takes a changeset and adds a secure random string in the `session_secret` field.
   """
-  def put_session_secret(changeset, length \\ 64) do
-    Changeset.put_change(changeset, :session_secret, random_string(length))
-  end
+  def put_session_secret(changeset, length \\ 64),
+    do: Changeset.put_change(changeset, :session_secret, random_string(length))
 
   # Generate a secure random string
   defp random_string(length) do

--- a/lib/entrance.ex
+++ b/lib/entrance.ex
@@ -43,6 +43,17 @@ defmodule Entrance do
   ```
   """
   def authenticate_by(user_module \\ nil, fields, password) do
+    unless Keyword.keyword?(fields) do
+      raise """
+      authenticate_by/2 and authenticate_by/3 must receive a keyword list
+
+      Here is some examples:
+
+        Entrance.authenticate_by([email: "joe@dirt.com", admin: true], "brandyr00lz")
+        Entrance.authenticate_by(Customer, [email: "joe@dirt.com", admin: true], "brandyr00lz")
+      """
+    end
+
     authenticate_action(user_module, fields, password)
   end
 
@@ -76,17 +87,6 @@ defmodule Entrance do
   end
 
   defp authenticate_action(user_module, fields, password) do
-    unless Keyword.keyword?(fields) do
-      raise """
-      authenticate_by/2 and authenticate_by/3 must receive a keyword list
-
-      Here is some examples:
-
-        Entrance.authenticate_by([email: "joe@dirt.com", admin: true], "brandyr00lz")
-        Entrance.authenticate_by(Customer, [email: "joe@dirt.com", admin: true], "brandyr00lz")
-      """
-    end
-
     user_module = user_module || get_user_module()
     user = repo_module().get_by(user_module, fields)
 
@@ -126,7 +126,8 @@ defmodule Entrance do
           config :entrance,
             repo: MyApp.Repo,
             secure_with: Entrance.Auth.Bcrypt,
-            user_module: user: MyApp.User
+            user_module: MyApp.User
+            default_authenticable_field: :email
         """
 
       module ->

--- a/lib/entrance.ex
+++ b/lib/entrance.ex
@@ -8,40 +8,40 @@ defmodule Entrance do
   Authenticates a user by the default authenticable field (defined in config) and password. Returns the user if the
   user is found and the password is correct, otherwise nil. For example, if the default authenticable field configured is :email, it will try match with the :email field of user schema.
 
-  Requires `user_module`, `secure_with`, `repo` and `default_authenticable_field` to be configured via
+  Requires `user_module`, `security_module`, `repo` and `default_authenticable_field` to be configured via
   `Mix.Config`. See [README.md] for an example.
 
   ```
-  Entrance.authenticate("joe@dirt.com", "brandyr00lz")
+  Entrance.auth("joe@dirt.com", "brandyr00lz")
   ```
 
   If you want to authenticate other modules, you can pass in the module directly.
 
   ```
-  Entrance.authenticate(Customer, "brandy@dirt.com", "super-password")
+  Entrance.auth(Customer, "brandy@dirt.com", "super-password")
   ```
   """
-  def authenticate(user_module \\ nil, field, password),
-    do: authenticate_action(user_module, [{default_authenticable_field(), field}], password)
+  def auth(user_module \\ nil, field, password),
+    do: auth_action(user_module, [{get_default_authenticable_field(), field}], password)
 
   @doc """
-  Similar to authenticate/2, but authenticates a user by one or more differents fields. Returns the user if the
+  Similar to auth/2, but authenticates a user by one or more differents fields. Returns the user if the
   user is found and the password is correct, otherwise nil.
 
-  Requires `user_module`, `secure_with`, and `repo` to be configured via
+  Requires `user_module`, `security_module`, and `repo` to be configured via
   `Mix.Config`. See [README.md] for an example.
 
   ```
-  Entrance.authenticate_by([email: "joe@dirt.com", admin: true], "brandyr00lz")
+  Entrance.auth_by([email: "joe@dirt.com", admin: true], "brandyr00lz")
   ```
 
   If you want to authenticate other modules, you can pass in the module directly.
 
   ```
-  Entrance.authenticate_by(Customer, [nickname: "truehenrique", admin: true], "super-password")
+  Entrance.auth_by(Customer, [nickname: "truehenrique", admin: true], "super-password")
   ```
   """
-  def authenticate_by(user_module \\ nil, fields, password) do
+  def auth_by(user_module \\ nil, fields, password) do
     unless Keyword.keyword?(fields) do
       raise """
       Entrance.authenticate_by/2 must receive a keyword list
@@ -53,24 +53,24 @@ defmodule Entrance do
       """
     end
 
-    authenticate_action(user_module, fields, password)
+    auth_action(user_module, fields, password)
   end
 
   @doc """
   Authenticates a user. Returns true if the user's password and the given
   password match based on the strategy configured, otherwise false.
 
-  Use `authenticate/2` if if you would to authenticate by email and password.
+  Use `auth/2` if if you would to authenticate by email and password.
 
-  Requires `user_module`, `secure_with`, and `repo` to be configured via
+  Requires `user_module`, `security_module`, and `repo` to be configured via
   `Mix.Config`. See [README.md] for an example.
 
   ```
   user = Myapp.Repo.get(Myapp.User, 1)
-  Entrance.authenticate_user(user, "brandyr00lz")
+  Entrance.auth_user(user, "brandyr00lz")
   ```
   """
-  def authenticate_user(user, password), do: auth_module().authenticate(user, password)
+  def auth_user(user, password), do: security_module().auth(user, password)
 
   @doc """
   Returns true if passed in `conn`s `assigns` has a non-nil `:current_user`,
@@ -81,16 +81,16 @@ defmodule Entrance do
   """
   def logged_in?(conn), do: conn.assigns[:current_user] != nil
 
-  defp authenticate_action(user_module, fields, password) do
+  defp auth_action(user_module, fields, password) do
     user_module = user_module || get_user_module()
     user = repo_module().get_by(user_module, fields)
 
     cond do
-      user && authenticate_user(user, password) ->
+      user && auth_user(user, password) ->
         user
 
       true ->
-        auth_module().no_user_verify()
+        security_module().no_user_verify()
         nil
 
       user ->
@@ -102,9 +102,9 @@ defmodule Entrance do
 
   defp get_user_module, do: get_module(:user_module)
 
-  defp auth_module, do: get_module(:secure_with)
+  defp security_module, do: get_module(:security_module)
 
-  defp default_authenticable_field, do: get_module(:default_authenticable_field)
+  defp get_default_authenticable_field, do: get_module(:default_authenticable_field)
 
   defp get_module(name) do
     case Application.get_env(:entrance, name) do
@@ -116,7 +116,7 @@ defmodule Entrance do
 
           config :entrance,
             repo: MyApp.Repo,
-            secure_with: Entrance.Auth.Bcrypt,
+            security_module: Entrance.Auth.Bcrypt,
             user_module: MyApp.User,
             default_authenticable_field: :email
         """

--- a/lib/entrance.ex
+++ b/lib/entrance.ex
@@ -5,11 +5,11 @@ defmodule Entrance do
   """
 
   @doc """
-  Authenticates a user by the default authenticable field (defined in config) and password. Returns the user if the
-  user is found and the password is correct, otherwise nil. For example, if the default authenticable field configured is :email, it will try match with the :email field of user schema.
+  Authenticates a user by the default authenticable field (defined in your configurations) and password. Returns the user if the
+  user is found and the password is correct, otherwise nil. For example, if the default authenticable field configured is `:email`, it will try match with the `:email` field of user schema.
 
   Requires `user_module`, `security_module`, `repo` and `default_authenticable_field` to be configured via
-  `Mix.Config`. See [README.md] for an example.
+  `Mix.Config`.
 
   ```
   Entrance.auth("joe@dirt.com", "brandyr00lz")
@@ -21,15 +21,15 @@ defmodule Entrance do
   Entrance.auth(Customer, "brandy@dirt.com", "super-password")
   ```
   """
-  def auth(user_module \\ nil, field, password),
-    do: auth_action(user_module, [{get_default_authenticable_field(), field}], password)
+  def auth(user_module \\ nil, field_value, password),
+    do: auth_action(user_module, [{get_default_authenticable_field(), field_value}], password)
 
   @doc """
   Similar to auth/2, but authenticates a user by one or more differents fields. Returns the user if the
   user is found and the password is correct, otherwise nil.
 
   Requires `user_module`, `security_module`, and `repo` to be configured via
-  `Mix.Config`. See [README.md] for an example.
+  `Mix.Config`.
 
   ```
   Entrance.auth_by([email: "joe@dirt.com", admin: true], "brandyr00lz")
@@ -41,8 +41,8 @@ defmodule Entrance do
   Entrance.auth_by(Customer, [nickname: "truehenrique", admin: true], "super-password")
   ```
   """
-  def auth_by(user_module \\ nil, fields, password) do
-    unless Keyword.keyword?(fields) do
+  def auth_by(user_module \\ nil, fields_values, password) do
+    unless Keyword.keyword?(fields_values) do
       raise """
       Entrance.authenticate_by/2 must receive a keyword list
 
@@ -53,17 +53,15 @@ defmodule Entrance do
       """
     end
 
-    auth_action(user_module, fields, password)
+    auth_action(user_module, fields_values, password)
   end
 
   @doc """
   Authenticates a user. Returns true if the user's password and the given
-  password match based on the strategy configured, otherwise false.
-
-  Use `auth/2` if if you would to authenticate by email and password.
+  password match based on the `security_module` strategy configured, otherwise false.
 
   Requires `user_module`, `security_module`, and `repo` to be configured via
-  `Mix.Config`. See [README.md] for an example.
+  `Mix.Config`.
 
   ```
   user = Myapp.Repo.get(Myapp.User, 1)

--- a/lib/entrance.ex
+++ b/lib/entrance.ex
@@ -21,9 +21,8 @@ defmodule Entrance do
   Entrance.authenticate(Customer, "brandy@dirt.com", "super-password")
   ```
   """
-  def authenticate(user_module \\ nil, email, password) do
-    authenticate_action(user_module, [email: email], password)
-  end
+  def authenticate(user_module \\ nil, email, password),
+    do: authenticate_action(user_module, [email: email], password)
 
   @doc """
   Similar to authenticate/2, but can authenticates a user with differents fields, and even more than one field. Returns the user if the
@@ -45,7 +44,7 @@ defmodule Entrance do
   def authenticate_by(user_module \\ nil, fields, password) do
     unless Keyword.keyword?(fields) do
       raise """
-      authenticate_by/2 and authenticate_by/3 must receive a keyword list
+      authenticate_by/3 must receive a keyword list
 
       Here is some examples:
 
@@ -71,9 +70,7 @@ defmodule Entrance do
   Entrance.authenticate_user(user, "brandyr00lz")
   ```
   """
-  def authenticate_user(user, password) do
-    auth_module().authenticate(user, password)
-  end
+  def authenticate_user(user, password), do: auth_module().authenticate(user, password)
 
   @doc """
   Returns true if passed in `conn`s `assigns` has a non-nil `:current_user`,
@@ -82,9 +79,7 @@ defmodule Entrance do
   Make sure your pipeline uses a login plug to fetch the current user for this
   function to work correctly..
   """
-  def logged_in?(conn) do
-    conn.assigns[:current_user] != nil
-  end
+  def logged_in?(conn), do: conn.assigns[:current_user] != nil
 
   defp authenticate_action(user_module, fields, password) do
     user_module = user_module || get_user_module()
@@ -103,17 +98,11 @@ defmodule Entrance do
     end
   end
 
-  defp repo_module do
-    get_module(:repo)
-  end
+  defp repo_module, do: get_module(:repo)
 
-  defp get_user_module do
-    get_module(:user_module)
-  end
+  defp get_user_module, do: get_module(:user_module)
 
-  defp auth_module do
-    get_module(:secure_with)
-  end
+  defp auth_module, do: get_module(:secure_with)
 
   defp get_module(name) do
     case Application.get_env(:entrance, name) do

--- a/lib/entrance.ex
+++ b/lib/entrance.ex
@@ -126,7 +126,7 @@ defmodule Entrance do
           config :entrance,
             repo: MyApp.Repo,
             secure_with: Entrance.Auth.Bcrypt,
-            authenticable_modules: [user: MyApp.User] # future updates
+            user_module: user: MyApp.User
         """
 
       module ->

--- a/lib/entrance.ex
+++ b/lib/entrance.ex
@@ -5,10 +5,10 @@ defmodule Entrance do
   """
 
   @doc """
-  Authenticates a user by their email and password. Returns the user if the
-  user is found and the password is correct, otherwise nil.
+  Authenticates a user by the default authenticable field (defined in config) and password. Returns the user if the
+  user is found and the password is correct, otherwise nil. For example, if the default authenticable field configured is :email, it will try match with the :email field of user schema.
 
-  Requires `user_module`, `secure_with`, and `repo` to be configured via
+  Requires `user_module`, `secure_with`, `repo` and `default_authenticable_field` to be configured via
   `Mix.Config`. See [README.md] for an example.
 
   ```
@@ -21,11 +21,11 @@ defmodule Entrance do
   Entrance.authenticate(Customer, "brandy@dirt.com", "super-password")
   ```
   """
-  def authenticate(user_module \\ nil, email, password),
-    do: authenticate_action(user_module, [email: email], password)
+  def authenticate(user_module \\ nil, field, password),
+    do: authenticate_action(user_module, [{default_authenticable_field(), field}], password)
 
   @doc """
-  Similar to authenticate/2, but can authenticates a user with differents fields, and even more than one field. Returns the user if the
+  Similar to authenticate/2, but authenticates a user by one or more differents fields. Returns the user if the
   user is found and the password is correct, otherwise nil.
 
   Requires `user_module`, `secure_with`, and `repo` to be configured via
@@ -44,7 +44,7 @@ defmodule Entrance do
   def authenticate_by(user_module \\ nil, fields, password) do
     unless Keyword.keyword?(fields) do
       raise """
-      authenticate_by/3 must receive a keyword list
+      Entrance.authenticate_by/2 must receive a keyword list
 
       Here is some examples:
 
@@ -104,6 +104,8 @@ defmodule Entrance do
 
   defp auth_module, do: get_module(:secure_with)
 
+  defp default_authenticable_field, do: get_module(:default_authenticable_field)
+
   defp get_module(name) do
     case Application.get_env(:entrance, name) do
       nil ->
@@ -115,7 +117,7 @@ defmodule Entrance do
           config :entrance,
             repo: MyApp.Repo,
             secure_with: Entrance.Auth.Bcrypt,
-            user_module: MyApp.User
+            user_module: MyApp.User,
             default_authenticable_field: :email
         """
 

--- a/lib/login/session.ex
+++ b/lib/login/session.ex
@@ -27,11 +27,11 @@ defmodule Entrance.Login.Session do
   """
   def get_current_user(conn) do
     id = Plug.Conn.get_session(conn, @session_key)
-    secret = Plug.Conn.get_session(conn, @session_secret)
-    repo = Application.get_env(:entrance, :repo)
-    user_module = Application.get_env(:entrance, :user_module)
 
     if !is_nil(id) do
+      secret = Plug.Conn.get_session(conn, @session_secret)
+      repo = Application.get_env(:entrance, :repo)
+      user_module = Application.get_env(:entrance, :user_module)
       repo.get_by(user_module, id: id, session_secret: secret)
     end
   end

--- a/test/auth/bcrypt_test.exs
+++ b/test/auth/bcrypt_test.exs
@@ -20,29 +20,33 @@ defmodule Entrance.Auth.BcryptTest do
     end
   end
 
-  test "hash_password sets encrypted password on changeset when virtual field is present" do
-    changeset = FakeUser.changeset(%{password: "foobar"})
+  describe "Bcrypt.hash_password/0" do
+    test "sets encrypted password on changeset when virtual field is present" do
+      changeset = FakeUser.changeset(%{password: "foobar"})
 
-    assert changeset.changes[:hashed_password]
+      assert changeset.changes[:hashed_password]
+    end
+
+    test "does not set encrypted password on changeset when virtual field is not present" do
+      changeset = FakeUser.changeset(%{})
+
+      refute changeset.changes[:hashed_password]
+    end
   end
 
-  test "hash_password does not set encrypted password on changeset when virtual field is not present" do
-    changeset = FakeUser.changeset(%{})
+  describe "Bcrypt.authenticate/2" do
+    test "authenticate returns true when password matches" do
+      password = "secure"
+      user = %FakeUser{hashed_password: Bcrypt.hash_pwd_salt(password)}
 
-    refute changeset.changes[:hashed_password]
-  end
+      assert EntranceBcrypt.authenticate(user, password)
+    end
 
-  test "authenticate returns true when password matches" do
-    password = "secure"
-    user = %FakeUser{hashed_password: Bcrypt.hash_pwd_salt(password)}
+    test "authenticate returns false when password does not match" do
+      password = "secure"
+      user = %FakeUser{hashed_password: Bcrypt.hash_pwd_salt(password)}
 
-    assert EntranceBcrypt.authenticate(user, password)
-  end
-
-  test "authenticate returns false when password does not match" do
-    password = "secure"
-    user = %FakeUser{hashed_password: Bcrypt.hash_pwd_salt(password)}
-
-    refute EntranceBcrypt.authenticate(user, "wrong")
+      refute EntranceBcrypt.authenticate(user, "wrong")
+    end
   end
 end

--- a/test/auth/bcrypt_test.exs
+++ b/test/auth/bcrypt_test.exs
@@ -39,14 +39,14 @@ defmodule Entrance.Auth.BcryptTest do
       password = "secure"
       user = %FakeUser{hashed_password: Bcrypt.hash_pwd_salt(password)}
 
-      assert EntranceBcrypt.authenticate(user, password)
+      assert EntranceBcrypt.auth(user, password)
     end
 
     test "authenticate returns false when password does not match" do
       password = "secure"
       user = %FakeUser{hashed_password: Bcrypt.hash_pwd_salt(password)}
 
-      refute EntranceBcrypt.authenticate(user, "wrong")
+      refute EntranceBcrypt.auth(user, "wrong")
     end
   end
 end

--- a/test/auth/secret_test.exs
+++ b/test/auth/secret_test.exs
@@ -16,20 +16,22 @@ defmodule Entrance.Auth.SecretTest do
     end
   end
 
-  test "put_session_secret/2 does generate an random session key" do
-    changeset = FakeUser.changeset(%{}) |> Secret.put_session_secret()
-    assert changeset.changes[:session_secret]
-  end
+  describe "Secret.put_session_secret/2" do
+    test "does generate an random session key" do
+      changeset = FakeUser.changeset(%{}) |> Secret.put_session_secret()
+      assert changeset.changes[:session_secret]
+    end
 
-  test "put_session_secret/2 does generate different random session keys for users" do
-    changeset = FakeUser.changeset(%{}) |> Secret.put_session_secret()
-    changeset2 = FakeUser.changeset(%{}) |> Secret.put_session_secret()
-    assert changeset.changes.session_secret != changeset2.changes.session_secret
-  end
+    test "does generate different random session keys for users" do
+      changeset = FakeUser.changeset(%{}) |> Secret.put_session_secret()
+      changeset2 = FakeUser.changeset(%{}) |> Secret.put_session_secret()
+      assert changeset.changes.session_secret != changeset2.changes.session_secret
+    end
 
-  test "put_session_secret/2 does generate different random session keys for the same user" do
-    changeset = FakeUser.changeset(%{}) |> Secret.put_session_secret()
-    changeset2 = changeset |> Secret.put_session_secret()
-    assert changeset.changes.session_secret != changeset2.changes.session_secret
+    test "does generate different random session keys for the same user" do
+      changeset = FakeUser.changeset(%{}) |> Secret.put_session_secret()
+      changeset2 = changeset |> Secret.put_session_secret()
+      assert changeset.changes.session_secret != changeset2.changes.session_secret
+    end
   end
 end

--- a/test/entrance_test.exs
+++ b/test/entrance_test.exs
@@ -45,18 +45,18 @@ defmodule EntranceTest do
     end
   end
 
-  describe "Entrance.authenticate/3" do
+  describe "Entrance.auth/3" do
     test "takes valid email and valid password and returns true" do
       Application.put_all_env(
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt,
+          security_module: Entrance.Auth.Bcrypt,
           default_authenticable_field: @default_authenticable_field
         ]
       )
 
-      assert Entrance.authenticate(@valid_email, "password").email == @valid_email
+      assert Entrance.auth(@valid_email, "password").email == @valid_email
     end
 
     test "raises error whith wrong configurations" do
@@ -64,14 +64,16 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt,
+          security_module: Entrance.Auth.Bcrypt,
           default_authenticable_field: nil
         ]
       )
 
-      assert_raise RuntimeError, ~r/You must add `default_authenticable_field` to `entrance`/, fn ->
-        Entrance.authenticate(@valid_email, "password")
-      end
+      assert_raise RuntimeError,
+                   ~r/You must add `default_authenticable_field` to `entrance`/,
+                   fn ->
+                     Entrance.auth(@valid_email, "password")
+                   end
     end
 
     test "takes invalid email and valid password and returns nil" do
@@ -79,12 +81,12 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt,
+          security_module: Entrance.Auth.Bcrypt,
           default_authenticable_field: @default_authenticable_field
         ]
       )
 
-      assert Entrance.authenticate("fake", "password") == nil
+      assert Entrance.auth("fake", "password") == nil
     end
 
     test "takes valid email and invalid password and returns nil" do
@@ -92,12 +94,12 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt,
+          security_module: Entrance.Auth.Bcrypt,
           default_authenticable_field: @default_authenticable_field
         ]
       )
 
-      assert Entrance.authenticate(@valid_email, "wrong") == nil
+      assert Entrance.auth(@valid_email, "wrong") == nil
     end
 
     test "takes an optional user module" do
@@ -105,20 +107,20 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt,
+          security_module: Entrance.Auth.Bcrypt,
           default_authenticable_field: @default_authenticable_field
         ]
       )
 
-      user = Entrance.authenticate(OtherFake, @valid_alternate_email, "password")
+      user = Entrance.auth(OtherFake, @valid_alternate_email, "password")
       assert user.email == @valid_alternate_email
     end
   end
 
-  describe "Entrance.authenticate_by/3" do
+  describe "Entrance.auth_by/3" do
     test "raise error when second params is not an keyword list" do
       assert_raise RuntimeError, ~r/must receive a keyword list/, fn ->
-        Entrance.authenticate_by("not a keyword list", "password")
+        Entrance.auth_by("not a keyword list", "password")
       end
     end
 
@@ -127,11 +129,11 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          security_module: Entrance.Auth.Bcrypt
         ]
       )
 
-      assert Entrance.authenticate_by([email: @valid_email], "password").email == @valid_email
+      assert Entrance.auth_by([email: @valid_email], "password").email == @valid_email
     end
 
     test "takes invalid email and valid password and returns nil" do
@@ -139,11 +141,11 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          security_module: Entrance.Auth.Bcrypt
         ]
       )
 
-      assert Entrance.authenticate_by([email: "fake"], "password") == nil
+      assert Entrance.auth_by([email: "fake"], "password") == nil
     end
 
     test "receives others fields for authentication match" do
@@ -151,11 +153,11 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          security_module: Entrance.Auth.Bcrypt
         ]
       )
 
-      assert Entrance.authenticate_by(
+      assert Entrance.auth_by(
                [email: @valid_email, other_field: "some_value"],
                "password"
              ).email == @valid_email
@@ -168,11 +170,11 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          security_module: Entrance.Auth.Bcrypt
         ]
       )
 
-      assert Entrance.authenticate_by([email: @valid_email], "wrong") == nil
+      assert Entrance.auth_by([email: @valid_email], "wrong") == nil
     end
 
     test "takes an optional user module" do
@@ -180,11 +182,11 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          security_module: Entrance.Auth.Bcrypt
         ]
       )
 
-      user = Entrance.authenticate_by(OtherFake, [email: @valid_alternate_email], "password")
+      user = Entrance.auth_by(OtherFake, [email: @valid_alternate_email], "password")
       assert user.email == @valid_alternate_email
     end
   end

--- a/test/entrance_test.exs
+++ b/test/entrance_test.exs
@@ -22,6 +22,16 @@ defmodule EntranceTest do
 
     def get_by(Fake, email: _email), do: nil
 
+    def get_by(Fake, email: email, other_field: other_field) do
+      send(self(), {email, other_field})
+
+      %{
+        email: "joe@dirt.com",
+        other_field: other_field,
+        hashed_password: Bcrypt.hash_pwd_salt("password")
+      }
+    end
+
     def get(Fake, id) do
       if id == 1 do
         %{
@@ -34,74 +44,152 @@ defmodule EntranceTest do
     end
   end
 
-  test "authenticate/3 takes valid email and valid password and returns true" do
-    Application.put_all_env(
-      entrance: [
-        repo: FakeSuccessRepo,
-        user_module: Fake,
-        secure_with: Entrance.Auth.Bcrypt
-      ]
-    )
+  describe "Entrance.authenticate/3" do
+    test "takes valid email and valid password and returns true" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
 
-    assert Entrance.authenticate(@valid_email, "password").email == @valid_email
+      assert Entrance.authenticate(@valid_email, "password").email == @valid_email
+    end
+
+    test "takes invalid email and valid password and returns nil" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      assert Entrance.authenticate("fake", "password") == nil
+    end
+
+    test "takes valid email and invalid password and returns nil" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      assert Entrance.authenticate(@valid_email, "wrong") == nil
+    end
+
+    test "takes an optional user module" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      user = Entrance.authenticate(OtherFake, @valid_alternate_email, "password")
+      assert user.email == @valid_alternate_email
+    end
   end
 
-  test "authenticate/3 takes invalid email and valid password and returns nil" do
-    Application.put_all_env(
-      entrance: [
-        repo: FakeSuccessRepo,
-        user_module: Fake,
-        secure_with: Entrance.Auth.Bcrypt
-      ]
-    )
+  describe "Entrance.authenticate_by/3" do
+    test "raise error when second params is not an keyword list" do
+      assert_raise RuntimeError, ~r/must receive a keyword list/, fn ->
+        Entrance.authenticate_by("not a keyword list", "password")
+      end
+    end
 
-    assert Entrance.authenticate("fake", "password") == nil
+    test "takes valid email and valid password and returns true" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      assert Entrance.authenticate_by([email: @valid_email], "password").email == @valid_email
+    end
+
+    test "takes invalid email and valid password and returns nil" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      assert Entrance.authenticate_by([email: "fake"], "password") == nil
+    end
+
+    test "receives others fields for authentication match" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      assert Entrance.authenticate_by(
+               [email: @valid_email, other_field: "some_value"],
+               "password"
+             ).email == @valid_email
+
+      assert_received {@valid_email, "some_value"}
+    end
+
+    test "takes valid email and invalid password and returns nil" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      assert Entrance.authenticate_by([email: @valid_email], "wrong") == nil
+    end
+
+    test "takes an optional user module" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt
+        ]
+      )
+
+      user = Entrance.authenticate_by(OtherFake, [email: @valid_alternate_email], "password")
+      assert user.email == @valid_alternate_email
+    end
   end
 
-  test "authenticate/3 takes valid email and invalid password and returns nil" do
-    Application.put_all_env(
-      entrance: [
-        repo: FakeSuccessRepo,
-        user_module: Fake,
-        secure_with: Entrance.Auth.Bcrypt
-      ]
-    )
+  describe "Entrance.login/1" do
+    test "returns true if the user is logged in" do
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.assign(:current_user, %{})
 
-    assert Entrance.authenticate(@valid_email, "wrong") == nil
-  end
+      assert Entrance.logged_in?(conn)
+    end
 
-  test "authenticate/3 takes an optional user module" do
-    Application.put_all_env(
-      entrance: [
-        repo: FakeSuccessRepo,
-        user_module: Fake,
-        secure_with: Entrance.Auth.Bcrypt
-      ]
-    )
+    test "returns false if the current_user is nil" do
+      conn =
+        %Plug.Conn{}
+        |> Plug.Conn.assign(:current_user, nil)
 
-    user = Entrance.authenticate(OtherFake, @valid_alternate_email, "password")
-    assert user.email == @valid_alternate_email
-  end
+      refute Entrance.logged_in?(conn)
+    end
 
-  test "login/1 returns true if the user is logged in" do
-    conn =
-      %Plug.Conn{}
-      |> Plug.Conn.assign(:current_user, %{})
+    test "returns false if the current_user is not present" do
+      conn = %Plug.Conn{}
 
-    assert Entrance.logged_in?(conn)
-  end
-
-  test "login/1 returns false if the current_user is nil" do
-    conn =
-      %Plug.Conn{}
-      |> Plug.Conn.assign(:current_user, nil)
-
-    refute Entrance.logged_in?(conn)
-  end
-
-  test "login/1 returns false if the current_user is not present" do
-    conn = %Plug.Conn{}
-
-    refute Entrance.logged_in?(conn)
+      refute Entrance.logged_in?(conn)
+    end
   end
 end

--- a/test/entrance_test.exs
+++ b/test/entrance_test.exs
@@ -2,6 +2,7 @@ defmodule EntranceTest do
   use Entrance.ConnCase
   doctest Entrance
 
+  @default_authenticable_field :email
   @valid_email "joe@dirt.com"
   @valid_alternate_email "brandy@dirt.com"
 
@@ -50,11 +51,27 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          secure_with: Entrance.Auth.Bcrypt,
+          default_authenticable_field: @default_authenticable_field
         ]
       )
 
       assert Entrance.authenticate(@valid_email, "password").email == @valid_email
+    end
+
+    test "raises error whith wrong configurations" do
+      Application.put_all_env(
+        entrance: [
+          repo: FakeSuccessRepo,
+          user_module: Fake,
+          secure_with: Entrance.Auth.Bcrypt,
+          default_authenticable_field: nil
+        ]
+      )
+
+      assert_raise RuntimeError, ~r/You must add `default_authenticable_field` to `entrance`/, fn ->
+        Entrance.authenticate(@valid_email, "password")
+      end
     end
 
     test "takes invalid email and valid password and returns nil" do
@@ -62,7 +79,8 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          secure_with: Entrance.Auth.Bcrypt,
+          default_authenticable_field: @default_authenticable_field
         ]
       )
 
@@ -74,7 +92,8 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          secure_with: Entrance.Auth.Bcrypt,
+          default_authenticable_field: @default_authenticable_field
         ]
       )
 
@@ -86,7 +105,8 @@ defmodule EntranceTest do
         entrance: [
           repo: FakeSuccessRepo,
           user_module: Fake,
-          secure_with: Entrance.Auth.Bcrypt
+          secure_with: Entrance.Auth.Bcrypt,
+          default_authenticable_field: @default_authenticable_field
         ]
       )
 

--- a/test/login/session_test.exs
+++ b/test/login/session_test.exs
@@ -35,90 +35,94 @@ defmodule Entrance.Login.SessionTest do
     end
   end
 
-  test "login/1 sets :user_id on conn.session", %{conn: conn} do
-    conn = Session.login(conn, %{id: 1, session_secret: "abc"})
+  describe "Session.login/1" do
+    test "sets :user_id on conn.session", %{conn: conn} do
+      conn = Session.login(conn, %{id: 1, session_secret: "abc"})
 
-    assert Plug.Conn.get_session(conn, :user_id) == 1
-    assert Plug.Conn.get_session(conn, :session_secret) == "abc"
+      assert Plug.Conn.get_session(conn, :user_id) == 1
+      assert Plug.Conn.get_session(conn, :session_secret) == "abc"
+    end
   end
 
-  test "get_current_user/1 returns user when exists", %{conn: conn} do
-    Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
+  describe "Session.get_current_user/1" do
+    test "returns user when exists", %{conn: conn} do
+      Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
 
-    conn =
-      conn
-      |> Plug.Conn.put_session(:user_id, @valid_id)
-      |> Plug.Conn.put_session(:session_secret, @valid_secret)
+      conn =
+        conn
+        |> Plug.Conn.put_session(:user_id, @valid_id)
+        |> Plug.Conn.put_session(:session_secret, @valid_secret)
 
-    assert Session.get_current_user(conn)
-  end
+      assert Session.get_current_user(conn)
+    end
 
-  test "get_current_user/1 accepts nil as a session_secret", %{conn: conn} do
-    Application.put_all_env(entrance: [repo: NilSuccessRepo, user_module: Fake])
+    test "accepts nil as a session_secret", %{conn: conn} do
+      Application.put_all_env(entrance: [repo: NilSuccessRepo, user_module: Fake])
 
-    conn =
-      conn
-      |> Plug.Conn.put_session(:user_id, @valid_id)
-      |> Plug.Conn.put_session(:session_secret, nil)
+      conn =
+        conn
+        |> Plug.Conn.put_session(:user_id, @valid_id)
+        |> Plug.Conn.put_session(:session_secret, nil)
 
-    assert Session.get_current_user(conn)
-  end
+      assert Session.get_current_user(conn)
+    end
 
-  test "get_current_user/1 won't accept just any session_secret just because this is set to nil",
-       %{conn: conn} do
-    Application.put_all_env(entrance: [repo: NilSuccessRepo, user_module: Fake])
+    test "won't accept just any session_secret just because this is set to nil",
+         %{conn: conn} do
+      Application.put_all_env(entrance: [repo: NilSuccessRepo, user_module: Fake])
 
-    conn =
-      conn
-      |> Plug.Conn.put_session(:user_id, @valid_id)
-      |> Plug.Conn.put_session(:session_secret, "abc")
+      conn =
+        conn
+        |> Plug.Conn.put_session(:user_id, @valid_id)
+        |> Plug.Conn.put_session(:session_secret, "abc")
 
-    refute Session.get_current_user(conn)
-  end
+      refute Session.get_current_user(conn)
+    end
 
-  test "get_current_user/1 won't accept a nil session_secret if this is not set to nil", %{
-    conn: conn
-  } do
-    Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
+    test "won't accept a nil session_secret if this is not set to nil", %{
+      conn: conn
+    } do
+      Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
 
-    conn =
-      conn
-      |> Plug.Conn.put_session(:user_id, @valid_id)
-      |> Plug.Conn.put_session(:session_secret, nil)
+      conn =
+        conn
+        |> Plug.Conn.put_session(:user_id, @valid_id)
+        |> Plug.Conn.put_session(:session_secret, nil)
 
-    refute Session.get_current_user(conn)
-  end
+      refute Session.get_current_user(conn)
+    end
 
-  test "get_current_user/1 returns nil when user does not exist", %{conn: conn} do
-    Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
+    test "returns nil when user does not exist", %{conn: conn} do
+      Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
 
-    conn =
-      conn
-      |> Plug.Conn.put_session(:user_id, @invalid_id)
-      |> Plug.Conn.put_session(:session_secret, @valid_secret)
+      conn =
+        conn
+        |> Plug.Conn.put_session(:user_id, @invalid_id)
+        |> Plug.Conn.put_session(:session_secret, @valid_secret)
 
-    refute Session.get_current_user(conn)
-  end
+      refute Session.get_current_user(conn)
+    end
 
-  test "get_current_user/1 returns nil when session_key does not match", %{conn: conn} do
-    Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
+    test "returns nil when session_key does not match", %{conn: conn} do
+      Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
 
-    conn =
-      conn
-      |> Plug.Conn.put_session(:user_id, @valid_id)
-      |> Plug.Conn.put_session(:session_secret, @invalid_secret)
+      conn =
+        conn
+        |> Plug.Conn.put_session(:user_id, @valid_id)
+        |> Plug.Conn.put_session(:session_secret, @invalid_secret)
 
-    refute Session.get_current_user(conn)
-  end
+      refute Session.get_current_user(conn)
+    end
 
-  test "get_current_user/1 returns nil when session_key and id do not match", %{conn: conn} do
-    Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
+    test "returns nil when session_key and id do not match", %{conn: conn} do
+      Application.put_all_env(entrance: [repo: FakeSuccessRepo, user_module: Fake])
 
-    conn =
-      conn
-      |> Plug.Conn.put_session(:user_id, @invalid_id)
-      |> Plug.Conn.put_session(:session_secret, @invalid_secret)
+      conn =
+        conn
+        |> Plug.Conn.put_session(:user_id, @invalid_id)
+        |> Plug.Conn.put_session(:session_secret, @invalid_secret)
 
-    refute Session.get_current_user(conn)
+      refute Session.get_current_user(conn)
+    end
   end
 end


### PR DESCRIPTION
- Change nomenclature from authenticate* to auth*
- Do some code refactors
- Add default_authenticable_field. Now it's possible to set any user schema field to be the default_authenticable_field in Entrance.auth/3 function
- Add Entrance.auth_by/3 function. Now it's possible to authenticate using more than one field of user schema
- Change the Mix.Config nomenclature to a more legible. Example:

Before:
```Elixir
    config :entrance,                                                                                                                                   
      repo: MyApp.Repo,                                                                                                                                 
      secure_with: Entrance.Auth.Bcrypt,                                                                                                            
      user_module: MyApp.User,              
```
After:
```Elixir
    config :entrance,                                                                                                                                   
      repo: MyApp.Repo,                                                                                                                                 
      security_module: Entrance.Auth.Bcrypt,                                                                                                            
      user_module: MyApp.User,                                                                                                                          
      default_authenticable_field: :email    
```
